### PR TITLE
URL building and filters handling improvements

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -45,11 +45,11 @@
                 }
 
                 # ensure that profile id begings with 'ga:'
-                if (!any(grep("ga:", ids))) {
+                if (!grepl("ga:", ids)) {
                     ids <- paste("ga:", ids, sep = "")
                 }
 
-                # remove whitespace from metrics and dimensions
+                # remove whitespaces from metrics and dimensions
                 metrics <- gsub("\\s", "", metrics)
                 dimensions <- gsub("\\s", "", dimensions)
 
@@ -63,7 +63,7 @@
                                paste("dimensions", dimensions, sep = "="),
                                paste("start-index", start, sep = "="),
                                paste("max-results", max, sep = "="),
-                               sep = "&", collapse = "")
+                               sep = "&", collapse = "")        
 
                 if (sort != "") {
                     query <- paste(query, paste("sort", sort, sep = "="), sep = "&", collapse = "")
@@ -75,6 +75,9 @@
                     query <- paste(query, paste("fields", fields, sep = "="), sep = "&", collapse = "")
                 }
                 if (filters != "") {
+                    filters <- gsub("\\s", "", filters)
+                    filters <- gsub("OR|\\|\\|", ",", filters)
+                    filters <- gsub("AND|&&", ";", filters)
                     query <- paste(query, paste("filters", curlEscape(filters), sep = "="), sep = "&", collapse = "")
                 }
 
@@ -84,10 +87,16 @@
                     return(url)
                 }
 
-                # get data and convert from json to list-format
                 # thanks to Schaun Wheeler this will not provoke the weird SSL-bug
+                if (.Platform$OS.type == "windows") {
+                    options(RCurlOptions = list(
+                        verbose = FALSE,
+                        capath = system.file("CurlSSL", "cacert.pem",
+                        package = "RCurl"), ssl.verifypeer = FALSE))
+                }
+
+                # get data and convert from json to list-format
                 # switched to use httr and jsonlite
-                options(RCurlOptions = list(verbose = FALSE, capath = system.file("CurlSSL", "cacert.pem", package = "RCurl"), ssl.verifypeer = FALSE))
                 request <- GET(url)
                 ga.data <- jsonlite::fromJSON(content(request, "text"))
 

--- a/R/mcf.R
+++ b/R/mcf.R
@@ -49,7 +49,7 @@
                     ids <- paste("ga:", ids, sep = "")
                 }
 
-                # remove whitespace from metrics and dimensions
+                # remove whitespaces from metrics and dimensions
                 metrics <- gsub("\\s", "", metrics)
                 dimensions <- gsub("\\s", "", dimensions)
 
@@ -77,6 +77,9 @@
                     query <- paste(query, paste("fields", fields, sep = "="), sep = "&", collapse = "")
                 }
                 if (filters != "") {
+                    filters <- gsub("\\s", "", filters)
+                    filters <- gsub("OR|\\|\\|", ",", filters)
+                    filters <- gsub("AND|&&", ";", filters)
                     query <- paste(query, paste("filters", curlEscape(filters), sep = "="), sep = "&", collapse = "")
                 }
 
@@ -84,6 +87,14 @@
 
                 if (return.url) {
                     return(url)
+                }
+
+                # thanks to Schaun Wheeler this will not provoke the weird SSL-bug
+                if (.Platform$OS.type == "windows") {
+                    options(RCurlOptions = list(
+                        verbose = FALSE,
+                        capath = system.file("CurlSSL", "cacert.pem",
+                        package = "RCurl"), ssl.verifypeer = FALSE))
                 }
 
                 # get data and convert from json to list-format
@@ -144,7 +155,7 @@
                 }
 
                 # convert to data.frame
-                if (!any(grep("MCF_SEQUENCE", ga.headers$dataType))) {
+                if (!grepl("MCF_SEQUENCE", ga.headers$dataType)) {
                     ga.data.df <- as.data.frame(do.call(rbind, lapply(ga.data$rows, unlist)), stringsAsFactors = FALSE)
                     # insert column names
                     names(ga.data.df) <- ga.headers$name

--- a/R/mgmt.R
+++ b/R/mgmt.R
@@ -1,7 +1,7 @@
 .extend.rga.mgmt <- function() {
     rga$methods(
         list(
-            getMGMTData = function(url, keep) {
+            getMGMTData = function(url, keep, start, max) {
                 query <- paste(paste("access_token", .self$getToken()$access_token, sep = "="),
                                paste("start-index", start, sep = "="),
                                paste("max-results", max, sep = "="), sep = "&")
@@ -16,28 +16,26 @@
             },
             getAccounts = function(start = 1, max = 1000) {
                 url <- "https://www.googleapis.com/analytics/v3/management/accounts"
-                return(.self$getMGMTData(url, c("id", "name", "created", "updated")))
+                return(.self$getMGMTData(url, c("id", "name", "created", "updated"), start = start, max = max))
             },
             getWebProperties = function(accountId = "~all", start = 1, max = 1000) {
                 url <- paste("https://www.googleapis.com/analytics/v3/management/accounts/",
                              accountId, "/webproperties", sep = "", collapse = "")
-                return(.self$getMGMTData(url, c("id", "name", "websiteUrl", "level", "industryVertical", "created", "updated")))
+                return(.self$getMGMTData(url, c("id", "name", "websiteUrl", "level", "industryVertical", "created", "updated"), start = start, max = max))
             },
             getProfiles = function(accountId = "~all", webPropertyId = "~all", start = 1, max = 1000) {
                 url <- paste("https://www.googleapis.com/analytics/v3/management/accounts/",
                              accountId, "/webproperties/", webPropertyId, "/profiles", sep = "", collapse = "")
-                # possible deparse.error, sapply(test$items,length)
-                return(.self$getMGMTData(url, c("id", "accountId", "webPropertyId", "name", "currency", "timezone", "eCommerceTracking", "websiteUrl", "created", "updated")))
+                return(.self$getMGMTData(url, c("id", "accountId", "webPropertyId", "name", "currency", "timezone", "eCommerceTracking", "websiteUrl", "created", "updated"), start = start, max = max))
             },
             getGoals = function(accountId = "~all", webPropertyId = "~all", profileId = "~all", start = 1, max = 1000) {
-                # FIX: deparse error
                 url <- paste("https://www.googleapis.com/analytics/v3/management/accounts/",
                              accountId, "/webproperties/", webPropertyId, "/profiles/", profileId, "/goals", sep = "", collapse = "")
-                return(.self$getMGMTData(url, c("id", "accountId", "webPropertyId", "profileId", "name", "value", "active", "type", "created", "updated")))
+                return(.self$getMGMTData(url, c("id", "accountId", "webPropertyId", "profileId", "name", "value", "active", "type", "created", "updated"), start = start, max = max))
             },
             getSegments = function(start = 1, max = 1000) {
                 url <- paste("https://www.googleapis.com/analytics/v3/management/segments", sep = "", collapse = "")
-                return(.self$getMGMTData(url, c("id", "segmentId", "name", "definition", "type")))
+                return(.self$getMGMTData(url, c("id", "segmentId", "name", "definition", "type"), start = start, max = max))
             }
         )
     )


### PR DESCRIPTION
Changelog:
- rename `processManagementData` to `getMGMTData` like as others rga functions;
- optimize `getMGMTData` function for less `paste` and `.self$getToken` calls;
- change build URLs logic according `httr` package: use `modify_url` function with `query` arg;
- change default `start.date` and `end.date` args in `.self$getData` and `.self$getMCFData` function: from "today" to "last week";
- improve filters handling: now you can use whitespaces and `OR`, `AND`, `||`, `&&` operators:
  - `ga$getData(profileid, filters = "ga:users < 3000 && ga:pageviews < 10000")`;
- apply `RCurlOptions` options only for Windows.
## 

wbr,
Artem
