### PR TITLE
Use ga:hits instead of ga:sessions for getFirstDate()

### DIFF
--- a/R/core.R
+++ b/R/core.R
@@ -120,7 +120,7 @@ rga$methods(
             if (ga.data$containsSampledData == "TRUE") {
                 isSampled <- TRUE
                 if (!walk) {
-                    message(sprintf("Notice: Data set sampled from %s sessions (%d%% of all sessions)", 
+                    message(sprintf("Notice: Data set sampled from %s sessions (%d%% of all sessions)",
                                     format(as.numeric(ga.data$sampleSize), big.mark=",", scientific=FALSE),
                                     round((as.numeric(ga.data$sampleSize) / as.numeric(ga.data$sampleSpace) * 100))))
                 }
@@ -180,7 +180,7 @@ rga$methods(
             } else {
                 attr(ga.data.df, "containsSampledData") <- FALSE
             }
-            
+
             # find formats
             formats <- ga.headers
 
@@ -220,7 +220,7 @@ rga$methods(
             return(ga.data.df)
         },
         getFirstDate = function(ids) {
-            first <- .self$getData(ids, start.date = "2005-01-01", filters = "ga:sessions!=0", max = 1, messages = FALSE)
+            first <- .self$getData(ids, start.date = "2005-01-01", filters = "ga:hits!=0", max = 1, messages = FALSE)
             return(first$date)
         },
         getDataInBatches = function(batchSize, total, ids, start.date, end.date, date.format,


### PR DESCRIPTION
These days, some people using Google Analytics for tracking offline
events via Measurement Protocol. As this feature is getting more
popular, it would be better to calculate the first date using “ga:hits”
and not just “ga:sessions”, as “ga:hits” will count not-interactive
hits that do not generate sessions but are also data activity.